### PR TITLE
AWS Amplify configuration

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+# This is used for deploying the frontend only (currently)
+version: 1
+frontend:
+    phases:
+        preBuild:
+            commands:
+                - npm ci --prefix client
+        build:
+            commands:
+                - npm run build --prefix client
+    artifacts:
+        baseDirectory: client/.next/server/app
+        files:
+            - "**/*"
+    cache:
+        paths:
+            - client/.next/cache/**/*
+            - client/node_modules/**/*


### PR DESCRIPTION
This tells AWS how to deploy the frontend app. Amplify is something vercel-like in AWS which watches for git pushes on a branch tied to an environment, then automatically deploys. It was listed as the [recommended approach](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html) for hosting a static site.

Note that my previous comments about not being able to use SSR are incorrect, apparently we still have access to a full Next backend. There are various ways you can configure it, but for now I think most stuff will magically work as expected.