### PR TITLE
Fix casing to match file

### DIFF
--- a/client/app/form/page.jsx
+++ b/client/app/form/page.jsx
@@ -1,4 +1,4 @@
-import Form from "@/components/Form";
+import Form from "@/components/form";
 
 export default function FormView() {
   return (


### PR DESCRIPTION
Previous worked locally but not in the AWS build. Not sure why, but I think this will fix it.