### PR TITLE
Request Form Time Range Inputs

### DIFF
--- a/client/app/form/page.jsx
+++ b/client/app/form/page.jsx
@@ -1,4 +1,4 @@
-import Form from "@/components/form";
+import Form from "@/components/form/Form";
 
 export default function FormView() {
   return (

--- a/client/components/form/Form.jsx
+++ b/client/components/form/Form.jsx
@@ -30,13 +30,13 @@ const schema = Joi.object({
     .pattern(new RegExp(/^[0-9]*$/))
     .length(10),
   address: Joi.string().required(),
-  earlyTime: Joi.number().min(9).max(16).required(),
-  lateTime: Joi.number()
+  earlyTimeHour: Joi.number().min(9).max(16).required(),
+  lateTimeHour: Joi.number()
     .min(10)
     .max(17)
     .required()
     // check that lateTime > earlyTime
-    .greater(Joi.ref("earlyTime")),
+    .greater(Joi.ref("earlyTimeHour")),
 });
 
 export default function Form() {
@@ -56,6 +56,7 @@ export default function Form() {
   const [errorPath, setErrorPath] = useState("");
   const [toast, setToast] = useState(false);
   const [toastMsg, setToastMsg] = useState("");
+  const [disableBtn, setDisableBtn] = useState(null);
 
   const handleToastClose = (event, reason) => {
     if (reason === "clickaway") {
@@ -67,17 +68,19 @@ export default function Form() {
 
   async function handleSubmit(e) {
     e.preventDefault();
+
+    const earlyTimeHour = earlyTime.hour();
+    const lateTimeHour = lateTime.hour();
     const { error, value } = schema.validate({
       name,
       email,
       phone,
       address,
-      earlyTime,
-      lateTime,
+      earlyTimeHour,
+      lateTimeHour,
     });
 
     if (error) {
-      console.log(error);
       setErrorMsg(error.details[0].message);
       setErrorPath(error.details[0].path[0]);
       return;
@@ -184,10 +187,12 @@ export default function Form() {
           setEarlyTime={setEarlyTime}
           lateTime={lateTime}
           setLateTime={setLateTime}
+          errorMsg={errorMsg}
+          setDisableBtn={setDisableBtn}
         />
 
         <div>
-          <Button variant="contained" type="submit">
+          <Button variant="contained" type="submit" disabled={!!disableBtn}>
             Submit
           </Button>
         </div>

--- a/client/components/form/Form.jsx
+++ b/client/components/form/Form.jsx
@@ -15,7 +15,6 @@ import { Button } from "@mui/material";
 import TimeRangeInput from "./TimeRangeInput";
 import { requestAppt } from "@/actions/form";
 
-// define schema
 const schema = Joi.object({
   name: Joi.string()
     .pattern(new RegExp(/^[A-Za-z]+$/))

--- a/client/components/form/Form.jsx
+++ b/client/components/form/Form.jsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Joi from "joi";
+import dayjs from "dayjs";
 import {
   Alert,
   FormControl,
@@ -29,6 +30,13 @@ const schema = Joi.object({
     .pattern(new RegExp(/^[0-9]*$/))
     .length(10),
   address: Joi.string().required(),
+  earlyTime: Joi.number().min(9).max(16).required(),
+  lateTime: Joi.number()
+    .min(10)
+    .max(17)
+    .required()
+    // check that lateTime > earlyTime
+    .greater(Joi.ref("earlyTime")),
 });
 
 export default function Form() {
@@ -36,6 +44,12 @@ export default function Form() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
+  const [earlyTime, setEarlyTime] = useState(
+    dayjs().hour(9).minute(0).second(0)
+  );
+  const [lateTime, setLateTime] = useState(
+    dayjs().hour(10).minute(0).second(0)
+  );
   const [address, setAddress] = useState("");
   // error state
   const [errorMsg, setErrorMsg] = useState("");
@@ -58,6 +72,8 @@ export default function Form() {
       email,
       phone,
       address,
+      earlyTime,
+      lateTime,
     });
 
     if (error) {
@@ -66,7 +82,7 @@ export default function Form() {
       setErrorPath(error.details[0].path[0]);
       return;
     }
-    const res = await requestAppt({ name, email, phone, address });
+    const res = await requestAppt(value);
 
     if (res) {
       setToast(true);
@@ -163,7 +179,12 @@ export default function Form() {
           )}
         </FormControl>
 
-        <TimeRangeInput />
+        <TimeRangeInput
+          earlyTime={earlyTime}
+          setEarlyTime={setEarlyTime}
+          lateTime={lateTime}
+          setLateTime={setLateTime}
+        />
 
         <div>
           <Button variant="contained" type="submit">

--- a/client/components/form/Form.jsx
+++ b/client/components/form/Form.jsx
@@ -11,6 +11,7 @@ import {
   Snackbar,
 } from "@mui/material";
 import { Button } from "@mui/material";
+import TimeRangeInput from "./TimeRangeInput";
 import { requestAppt } from "@/actions/form";
 
 // define schema
@@ -91,7 +92,7 @@ export default function Form() {
         </Alert>
       </Snackbar>
       <form
-        className="flex flex-col gap-4 w-1/2 mx-auto mt-12"
+        className="flex flex-col gap-4 w-full md:w-1/2 mx-auto mt-12"
         onSubmit={handleSubmit}
       >
         <FormControl>
@@ -161,6 +162,8 @@ export default function Form() {
             </FormHelperText>
           )}
         </FormControl>
+
+        <TimeRangeInput />
 
         <div>
           <Button variant="contained" type="submit">

--- a/client/components/form/TimeRangeInput.jsx
+++ b/client/components/form/TimeRangeInput.jsx
@@ -103,7 +103,10 @@ export default function TimeRangeInput({
             )}
           </Stack>
           {errorMsg && (
-            <FormHelperText error>Invalid time range</FormHelperText>
+            <FormHelperText error>
+              Invalid time range. Please make sure the time range is at least 1
+              hour.
+            </FormHelperText>
           )}
         </Stack>
       </Box>

--- a/client/components/form/TimeRangeInput.jsx
+++ b/client/components/form/TimeRangeInput.jsx
@@ -1,0 +1,28 @@
+import { Box, InputLabel, Stack, Typography } from "@mui/material";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+
+export default function TimeRangeInput() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Box className="border rounded-lg p-4 mt-4">
+        <Typography variant="subtitle2">Preferred Time</Typography>
+        <Stack direction={{ md: "row" }} gap={2} className="mt-2">
+          <Stack direction="column" className="w-full md:w-1/2">
+            <InputLabel htmlFor="start-time" className="m-1">
+              Earliest
+            </InputLabel>
+            <TimePicker id="start-time" />
+          </Stack>
+          <Stack direction="column" className="w-full md:w-1/2">
+            <InputLabel htmlFor="end-time" className="m-1">
+              Latest
+            </InputLabel>
+            <TimePicker id="end-time" />
+          </Stack>
+        </Stack>
+      </Box>
+    </LocalizationProvider>
+  );
+}

--- a/client/components/form/TimeRangeInput.jsx
+++ b/client/components/form/TimeRangeInput.jsx
@@ -1,25 +1,60 @@
-import { Box, InputLabel, Stack, Typography } from "@mui/material";
+import dayjs from "dayjs";
+import {
+  Box,
+  FormHelperText,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { TimePicker } from "@mui/x-date-pickers/TimePicker";
 
-export default function TimeRangeInput() {
+const nineAM = dayjs().set("hour", 9).startOf("hour");
+const tenAM = dayjs().set("hour", 10).startOf("hour");
+const fourPM = dayjs().set("hour", 16).startOf("hour");
+const fivePM = dayjs().set("hour", 17).startOf("hour");
+
+// time range must be minimum of 1 hour
+// earliest "early" time: 9am
+// earliest "latest" time: 10am
+// latest "early" time: 4pm
+// latest "late" time: 5pm
+
+export default function TimeRangeInput({
+  earlyTime,
+  setEarlyTime,
+  lateTime,
+  setLateTime,
+}) {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box className="border rounded-lg p-4 mt-4">
-        <Typography variant="subtitle2">Preferred Time</Typography>
-        <Stack direction={{ md: "row" }} gap={2} className="mt-2">
-          <Stack direction="column" className="w-full md:w-1/2">
-            <InputLabel htmlFor="start-time" className="m-1">
-              Earliest
-            </InputLabel>
-            <TimePicker id="start-time" />
+        <Typography variant="subtitle2">
+          Preferred Appointment Time Range
+        </Typography>
+        <Stack gap={2} className="mt-4">
+          <Stack direction="column" className="w-full">
+            <TimePicker
+              label="Earliest"
+              minTime={nineAM}
+              maxTime={fourPM}
+              timeSteps={{ minutes: 60 }}
+              value={earlyTime}
+              onChange={(newValue) => setEarlyTime(newValue.hour())}
+            />
+            <FormHelperText>Select a time between 9am and 4pm</FormHelperText>
           </Stack>
-          <Stack direction="column" className="w-full md:w-1/2">
-            <InputLabel htmlFor="end-time" className="m-1">
-              Latest
-            </InputLabel>
-            <TimePicker id="end-time" />
+          <Stack direction="column" className="w-full">
+            <TimePicker
+              label="Latest"
+              minTime={tenAM}
+              maxTime={fivePM}
+              timeSteps={{ minutes: 60 }}
+              value={lateTime}
+              onChange={(newValue) => setLateTime(newValue.hour())}
+            />
+            <FormHelperText>Select a time between 10am and 5pm</FormHelperText>
           </Stack>
         </Stack>
       </Box>

--- a/client/components/form/TimeRangeInput.jsx
+++ b/client/components/form/TimeRangeInput.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import dayjs from "dayjs";
 import {
   Box,
@@ -26,7 +27,11 @@ export default function TimeRangeInput({
   setEarlyTime,
   lateTime,
   setLateTime,
+  errorMsg,
+  setDisableBtn,
 }) {
+  const [earlyTimeErr, setEarlyTimeErr] = useState(null);
+  const [lateTimeErr, setLateTimeErr] = useState(null);
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box className="border rounded-lg p-4 mt-4">
@@ -41,9 +46,22 @@ export default function TimeRangeInput({
               maxTime={fourPM}
               timeSteps={{ minutes: 60 }}
               value={earlyTime}
-              onChange={(newValue) => setEarlyTime(newValue.hour())}
+              onError={(err) => {
+                setDisableBtn(err);
+                setEarlyTimeErr(err);
+              }}
+              onChange={(newValue) => {
+                setEarlyTime(newValue);
+              }}
             />
             <FormHelperText>Select a time between 9am and 4pm</FormHelperText>
+            {earlyTimeErr && (
+              <FormHelperText error>
+                {earlyTimeErr === "minTime"
+                  ? "Time cannot be before 9am"
+                  : "Time cannot be after 4pm"}
+              </FormHelperText>
+            )}
           </Stack>
           <Stack direction="column" className="w-full">
             <TimePicker
@@ -52,10 +70,26 @@ export default function TimeRangeInput({
               maxTime={fivePM}
               timeSteps={{ minutes: 60 }}
               value={lateTime}
-              onChange={(newValue) => setLateTime(newValue.hour())}
+              onError={(err) => {
+                setDisableBtn(err);
+                setLateTimeErr(err);
+              }}
+              onChange={(newValue) => {
+                setLateTime(newValue);
+              }}
             />
             <FormHelperText>Select a time between 10am and 5pm</FormHelperText>
+            {lateTimeErr && (
+              <FormHelperText error>
+                {lateTimeErr === "minTime"
+                  ? "Time cannot be before 10am"
+                  : "Time cannot be after 5pm"}
+              </FormHelperText>
+            )}
           </Stack>
+          {errorMsg && (
+            <FormHelperText error>Invalid time range</FormHelperText>
+          )}
         </Stack>
       </Box>
     </LocalizationProvider>

--- a/client/components/form/TimeRangeInput.jsx
+++ b/client/components/form/TimeRangeInput.jsx
@@ -32,6 +32,7 @@ export default function TimeRangeInput({
 }) {
   const [earlyTimeErr, setEarlyTimeErr] = useState(null);
   const [lateTimeErr, setLateTimeErr] = useState(null);
+
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box className="border rounded-lg p-4 mt-4">
@@ -49,6 +50,13 @@ export default function TimeRangeInput({
               onError={(err) => {
                 setDisableBtn(err);
                 setEarlyTimeErr(err);
+              }}
+              onSelectedSectionsChange={() => {
+                if (!dayjs(earlyTime).isValid()) {
+                  setEarlyTime(nineAM);
+                } else {
+                  setEarlyTime(earlyTime.minute(0).second(0));
+                }
               }}
               onChange={(newValue) => {
                 setEarlyTime(newValue);
@@ -73,6 +81,13 @@ export default function TimeRangeInput({
               onError={(err) => {
                 setDisableBtn(err);
                 setLateTimeErr(err);
+              }}
+              onSelectedSectionsChange={() => {
+                if (!dayjs(lateTime).isValid()) {
+                  setLateTime(tenAM);
+                } else {
+                  setLateTime(lateTime.minute(0).second(0));
+                }
               }}
               onChange={(newValue) => {
                 setLateTime(newValue);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,8 @@
         "@mui/icons-material": "^6.1.7",
         "@mui/material": "^6.1.6",
         "@mui/material-nextjs": "^6.1.6",
+        "@mui/x-date-pickers": "^7.22.2",
+        "dayjs": "^1.11.13",
         "joi": "^17.13.3",
         "next": "15.0.3",
         "react": "^18.3.1",
@@ -1112,6 +1114,90 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "7.22.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.22.2.tgz",
+      "integrity": "sha512-1KHSlIlnSoY3oHm820By8X344pIdGYqPvCCvfVHrEeeIQ/pHdxDD8tjZFWkFl4Jgm9oVFK90fMcqNZAzc+WaCw==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0",
+        "@mui/x-internals": "7.21.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.21.0.tgz",
+      "integrity": "sha512-94YNyZ0BhK5Z+Tkr90RKf47IVCW8R/1MvdUhh6MCQg6sZa74jsX+x+gEZ4kzuCqOsuyTyxikeQ8vVuCIQiP7UQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@next/env": {
       "version": "15.0.3",
@@ -2272,6 +2358,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.7",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,8 @@
     "@mui/icons-material": "^6.1.7",
     "@mui/material": "^6.1.6",
     "@mui/material-nextjs": "^6.1.6",
+    "@mui/x-date-pickers": "^7.22.2",
+    "dayjs": "^1.11.13",
     "joi": "^17.13.3",
     "next": "15.0.3",
     "react": "^18.3.1",

--- a/server/src/controllers/form.js
+++ b/server/src/controllers/form.js
@@ -1,16 +1,26 @@
 import Joi from "joi";
 
 const schema = Joi.object({
-  //! add regex to restrict to alpha only
-  name: Joi.string().alphanum().min(2).max(30).required(),
-  //! update tlds config (throws error if not present)
+  name: Joi.string()
+    .pattern(new RegExp(/^[A-Za-z]+$/))
+    .min(2)
+    .max(30)
+    .required(),
   email: Joi.string().email({
     minDomainSegments: 2,
-    tlds: { allow: ["com", "net"] },
+    tlds: { allow: false },
   }),
-  //! add regex to restrict to nums only
-  phone: Joi.string().alphanum().length(10),
+  phone: Joi.string()
+    .pattern(new RegExp(/^[0-9]*$/))
+    .length(10),
   address: Joi.string().required(),
+  earlyTimeHour: Joi.number().min(9).max(16).required(),
+  lateTimeHour: Joi.number()
+    .min(10)
+    .max(17)
+    .required()
+    // check that lateTime > earlyTime
+    .greater(Joi.ref("earlyTimeHour")),
 });
 
 export async function newAppt(req, res, next) {


### PR DESCRIPTION
### Testing instructions
- `cd client`
- `git pull` on main branch
- `git checkout form-date-field`
- `npm install`
- `npm run dev`
- Open browser, navigate to "/form"
- Use the Preferred Time inputs, testing the various validation rules listed below
- To submit validated form to server:
  - `cd server`
  - `npm run start:dev`
  - Fill out form and click Submit button. On success, you will be redirected to "/success" page.

### Branch Description

#### Main Changes
- Adds `@mui/x-date-pickers` and `dayjs` pkgs
- Adds a group of inputs where the user can select a preferred time range for their appointment
- Times can be entered manually or using a picker
- Picker only allows on-the-hour selections (i.e. 10:00am or 2:00pm).
- Handles validation errors and invalid times
- The inputs include the following validation:
  - Early time range must be between 9am and 4pm
  - Late time range must be between 10am and 5pm
  - Early and late times cannot be the same
  - Late time range must be greater than early time range
  - Times that are manually entered with minutes other then `:00` are rounded down when the user selects off the input
  - Likewise, if the user deletes the input, it is reset to a default value when the user selects off the input
  - The form Submit button is disabled if an input is in an active error state (but not if there is a validation error).
- If inputs pass validation, they are sent to the database as an integer representing the hour (i.e. 9 for 9am, 17 for 5pm, etc.). 

#### Other changes
- Fix my naming mistakes: changes form.js to Form.jsx, places file in `components/form` directory
- Adds updated Joi form schema to `server/src/controllers/form.js`