### PR TITLE
Fix check for admin only pages

### DIFF
--- a/client/middleware.js
+++ b/client/middleware.js
@@ -5,7 +5,7 @@ export default withAuth(
   // `withAuth` augments your `Request` with the user's token.
   function middleware(req) {
     const adminPaths = ['/admin-dashboard']
-    if (adminPaths.includes(req.nextUrl.pathname)) {
+    if (adminPaths.includes(req.nextUrl.pathname) && !req.nextauth.token.role === "admin") {
       return NextResponse.redirect(new URL("/unauthorized", req.nextUrl));
     }
   },


### PR DESCRIPTION
We accidentally left out the role check and always disallowed