### PR TITLE
Order appointments on appointments dashboard

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -21,6 +21,8 @@ NEXT_PUBLIC_LACITY_KEY=[key]
 GOOGLE_CLIENT_ID=[key]
 GOOGLE_CLIENT_SECRET=[key]
 AUTH_SECRET=[key]
+NEXT_PUBLIC_GOOGLE_API_KEY=[key]
+NEXT_PUBLIC_GOOGLE_APPOINTMENTS_MAP_ID=[id]
 ```
 
 Note: `NEXT_PUBLIC_` is a necessary prefix for any environment variable exposed to the browser.

--- a/client/actions/form.js
+++ b/client/actions/form.js
@@ -40,6 +40,7 @@ export async function fetchAppointments() {
     email: item.email,
     address: item.address,
     location: item.location,
+    schedule: item.schedule,
   }));
 }
 

--- a/client/components/admin_dashboard/Grid.jsx
+++ b/client/components/admin_dashboard/Grid.jsx
@@ -36,8 +36,19 @@ const formatPhone = (phone) => {
 };
 
 const columns = [
+  {
+    field: "visitOrder",
+    headerName: "Visit Order",
+    width: 190,
+    valueGetter: (_, row) => row.schedule.order,
+  },
   { field: "status", headerName: "Status", width: 190 },
-  { valueFormatter: formatName, field: "name", headerName: "Name", width: 190 },
+  {
+    valueFormatter: formatName,
+    field: "name",
+    headerName: "Name",
+    width: 190,
+  },
   {
     valueFormatter: formatDateCreated,
     field: "dateCreated",
@@ -72,7 +83,17 @@ export default function Grid({ rows }) {
       <DataGrid
         rows={rows}
         columns={columns}
-        initialState={{ pagination: { paginationModel } }}
+        initialState={{
+          pagination: { paginationModel },
+          sorting: {
+            sortModel: [
+              {
+                field: "visitOrder",
+                sort: "asc",
+              },
+            ],
+          },
+        }}
         pageSizeOptions={[15, 10]}
         sx={{ border: 0 }}
         getRowHeight={() => "auto"}

--- a/client/components/admin_dashboard/Map.jsx
+++ b/client/components/admin_dashboard/Map.jsx
@@ -1,6 +1,6 @@
 "use client";
-import { GoogleMap, LoadScript, Marker } from "@react-google-maps/api";
-import { googleApiKey } from "@/constants";
+import { GoogleMap, LoadScript } from "@react-google-maps/api";
+import { googleApiKey, appointmentsMapId } from "@/constants";
 import React, { useRef } from "react";
 
 export default function Map({ appointments }) {
@@ -11,31 +11,46 @@ export default function Map({ appointments }) {
     height: "400px",
   };
 
-  const startCoords = appointments.map((item) => ({ location: item.location, visitOrder: item.schedule.order, customerName: item.name }));
+  const startCoords = appointments.map(item => ({
+    location: item.location,
+    visitOrder: item.schedule.order,
+    customerName: item.name,
+  }));
 
-  const onLoad = (mapInstance) => {
+  const onLoad = async mapInstance => {
     mapRef.current = mapInstance;
-    const markerEle =
-      google.maps.marker?.AdvancedMarkerElement ?? google.maps.Marker;
+
+    const { AdvancedMarkerElement } = await google.maps.importLibrary(
+      "marker",
+    );
 
     startCoords.forEach(({ location, visitOrder, customerName }) => {
-      new markerEle({
+      const pin = new google.maps.marker.PinElement({
+        glyph: visitOrder.toString(),
+        glyphColor: "white",
+      });
+      new AdvancedMarkerElement({
         position: location,
         map: mapInstance,
         title: customerName,
-        label: visitOrder.toString(),
+        content: pin.element,
+        zIndex: 100000 - visitOrder, // Keeps earlier markers visible above later overlapping ones
       });
     });
   };
   console.log(appointments[0]);
 
   return (
-    <LoadScript googleMapsApiKey={`${googleApiKey}&v=beta`}>
+    <LoadScript
+      googleMapsApiKey={`${googleApiKey}`}
+      mapIds={[appointmentsMapId]}
+    >
       <GoogleMap
         mapContainerStyle={containerStyle}
         center={startCoords[0].location}
         zoom={15}
         onLoad={onLoad}
+        options={{ mapId: appointmentsMapId }}
       />
     </LoadScript>
   );

--- a/client/components/admin_dashboard/Map.jsx
+++ b/client/components/admin_dashboard/Map.jsx
@@ -11,17 +11,19 @@ export default function Map({ appointments }) {
     height: "400px",
   };
 
-  const startCoords = appointments.map((item) => item.location);
+  const startCoords = appointments.map((item) => ({ location: item.location, visitOrder: item.schedule.order, customerName: item.name }));
 
   const onLoad = (mapInstance) => {
     mapRef.current = mapInstance;
     const markerEle =
       google.maps.marker?.AdvancedMarkerElement ?? google.maps.Marker;
 
-    startCoords.forEach((location) => {
+    startCoords.forEach(({ location, visitOrder, customerName }) => {
       new markerEle({
         position: location,
         map: mapInstance,
+        title: customerName,
+        label: visitOrder.toString(),
       });
     });
   };
@@ -31,7 +33,7 @@ export default function Map({ appointments }) {
     <LoadScript googleMapsApiKey={`${googleApiKey}&v=beta`}>
       <GoogleMap
         mapContainerStyle={containerStyle}
-        center={startCoords[0]}
+        center={startCoords[0].location}
         zoom={15}
         onLoad={onLoad}
       />

--- a/client/constants/index.js
+++ b/client/constants/index.js
@@ -2,6 +2,7 @@
 export const serverUrl = process.env.SERVER_URL;
 export const laCityKey = process.env.NEXT_PUBLIC_LACITY_KEY;
 export const googleApiKey = process.env.NEXT_PUBLIC_GOOGLE_API_KEY;
+export const appointmentsMapId = process.env.NEXT_PUBLIC_GOOGLE_APPOINTMENTS_MAP_ID;
 
 // External API Endpoints
 export const LA_CITY_API_BASE_URL =

--- a/server/src/controllers/appointments.controller.js
+++ b/server/src/controllers/appointments.controller.js
@@ -1,4 +1,5 @@
 import Appointment from "../models/appointments.model.js";
+import { appendSchedule } from "../scheduling/scheduler.js";
 import appointmentSchema from "../validators/appointments.validator.js";
 
 export async function geocodeAddress(address) {
@@ -65,7 +66,8 @@ export async function newAppointment(req, res, next) {
 export async function getAllAppointments(req, res, next) {
   try {
     const appointments = await Appointment.find();
-    res.status(200).json(appointments);
+    const withScheduling = appendSchedule(appointments.map(a => a.toObject()));
+    res.status(200).json(withScheduling);
   } catch (error) {
     console.error("Error fetching appointments:", error);
     res.status(500);

--- a/server/src/scheduling/scheduler.js
+++ b/server/src/scheduling/scheduler.js
@@ -1,0 +1,28 @@
+/**
+ * Comparator function for 2 appointments. See the definition of array.sort()
+ */
+const appointmentComparator = (a, b) => a.dateCreated - b.dateCreated;
+
+/**
+ * Returns a new copy of the array, appending scheduling info to each appointment.
+ * Doesn't change the order of the array.
+ */
+const appendSchedule = (appointments) => {
+    const comparator = (a, b) => appointmentComparator(a.appointment, b.appointment)
+    const sortedArray = appointments.map((appointment, index) => ({ appointment, index })).sort(comparator);
+
+    const orderMap = new Map();
+    sortedArray.forEach((item, index) => {
+        const visitOrder = index + 1;
+        orderMap.set(item.index, visitOrder);
+    });
+
+    return appointments.map((appointment, index) => ({
+        ...appointment,
+        schedule: {
+            order: orderMap.get(index),
+        },
+    }))
+}
+
+export { appendSchedule }


### PR DESCRIPTION
I implemented the ordering server side. I think this make most sense. There is a schedule object on each appointment. Currently it only has an order property, but it could be extended if we want to do more complicated scheduling (eg plan multiple days).

Also fixed up the google maps code to be using their non-deprecated API. We were attempting to load AdvancedMarkerElement before, but it was always falling back to the old marker.

> [!NOTE]
> This adds a client environment variable `NEXT_PUBLIC_GOOGLE_APPOINTMENTS_MAP_ID`. The map needs to be added in the developer console of whoever's google API key you're using.
> https://developers.google.com/maps/documentation/get-map-id#create_map_ids