### PR TITLE
Restrict New Appointment Creation

### DIFF
--- a/server/src/controllers/appointments.controller.js
+++ b/server/src/controllers/appointments.controller.js
@@ -34,6 +34,21 @@ export async function newAppointment(req, res, next) {
     }
 
     const { earlyTimeHour, lateTimeHour, address, email, ...rest } = req.body;
+
+    // return error if doc with matching address and "Pending" or "Confirmed" status exists
+    const checkAddress = await Appointment.findOne({
+      "location.address": address,
+      status: { $in: ["Pending", "Confirmed"] },
+    });
+
+    if (checkAddress) {
+      res.status(409); // Conflict
+      return next({
+        message:
+          "An appointment for this address has already been scheduled. Please modify the existing appointment or choose a different address.",
+      });
+    }
+
     const coords = await geocodeAddress(address);
 
     // add request data to the database


### PR DESCRIPTION
Adds a query to `newAppointment` that returns the first appointment with the same address **and** a status of `Pending` or `Confirmed`. If an appointment is found the server returns a 409 error to the frontend, which displays the error in a toast.

To test, add a new appointment using the Request form, noting the address. By default the appointment will have a status of `Confirmed`.  Create another appointment using the same address to trigger the error.