### PR TITLE
Make address input full width

### DIFF
--- a/client/components/form/Autocomplete.css
+++ b/client/components/form/Autocomplete.css
@@ -1,0 +1,3 @@
+div.autoComplete_wrapper {
+    width: inherit;
+}

--- a/client/components/form/AutocompleteAddress.jsx
+++ b/client/components/form/AutocompleteAddress.jsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import autoComplete from "@tarekraafat/autocomplete.js";
 import { FormControl, InputLabel, Input, FormHelperText } from "@mui/material";
 import { serverUrl } from "@/constants";
+import "./Autocomplete.css"
 
 export default function Autocomplete({ setAddress, errorMsg }) {
   useEffect(() => {
@@ -49,7 +50,7 @@ export default function Autocomplete({ setAddress, errorMsg }) {
   return (
     <FormControl>
       <InputLabel htmlFor="address">Address</InputLabel>
-      <Input id="autoComplete" aria-describedby="address-autocomplete" />
+      <Input id="autoComplete" aria-describedby="address-autocomplete"  fullWidth/>
       {errorMsg && (
         <FormHelperText id="name-error-text" error>
           {errorMsg}


### PR DESCRIPTION
I don't know if this css file is the most elegant solution but it works. The problem was caused by the [extra div](https://tarekraafat.github.io/autoComplete.js/#/configuration?id=init) inserted by autocomplete post component load.