### PR TITLE
Fix deploy

### DIFF
--- a/client/amplify.yml
+++ b/client/amplify.yml
@@ -6,7 +6,7 @@ applications:
               build:
                   commands:
                       - npm ci
-                      - echo "NEXTAUTH_URL=$AWS_BRANCH.d1nf6f3sg6up3r.amplifyapp.com" >> .env
+                      - echo "NEXTAUTH_URL=https://$AWS_BRANCH.d3p7d19jg8832.amplifyapp.com" >> .env
                       - echo "NEXTAUTH_SECRET=$NEXTAUTH_SECRET" >> .env
                       - echo "GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID" >> .env
                       - echo "GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET" >> .env


### PR DESCRIPTION
Add missing protocol and update the URL to be the frontend in my AWS account:
https://main.d3p7d19jg8832.amplifyapp.com/

The main fix was manually done on the backend (still in Aya's account). I updated the version of node to 22 to match our local dev environments. It seems that the better-sqlite3 package is sensitive to the current version of node.